### PR TITLE
Added Helper Line for In-game Assistance

### DIFF
--- a/Assets/Materials/blue 1.mat
+++ b/Assets/Materials/blue 1.mat
@@ -8,12 +8,13 @@ Material:
   m_PrefabInternal: {fileID: 0}
   m_Name: blue 1
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: _EMISSION _GLOSSYREFLECTIONS_OFF _SPECULARHIGHLIGHTS_OFF
+  m_ShaderKeywords: _ALPHABLEND_ON _EMISSION _GLOSSYREFLECTIONS_OFF _SPECULARHIGHLIGHTS_OFF
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
@@ -58,19 +59,19 @@ Material:
     - _BumpScale: 1
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
-    - _DstBlend: 0
+    - _DstBlend: 10
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 0
     - _Metallic: 0
-    - _Mode: 0
+    - _Mode: 2
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 0
-    - _SrcBlend: 1
+    - _SrcBlend: 5
     - _UVSec: 0
-    - _ZWrite: 1
+    - _ZWrite: 0
     m_Colors:
     - _Color: {r: 0.13701835, g: 1, b: 0.066176474, a: 1}
     - _EmissionColor: {r: 0.5441177, g: 1, b: 0.66044617, a: 1}

--- a/Assets/Scenes/IceCubeLab.unity
+++ b/Assets/Scenes/IceCubeLab.unity
@@ -8119,7 +8119,7 @@ MonoBehaviour:
   OnStateChange:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   basicEditor: 0
   generalProps: 0
@@ -8137,7 +8137,7 @@ MonoBehaviour:
   OnTap:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   numberOfTapsRequired: 2
   timeLimit: Infinity
@@ -12065,42 +12065,42 @@ MonoBehaviour:
   OnFrameStart:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+FrameEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.TouchManager+FrameEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   OnFrameFinish:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+FrameEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.TouchManager+FrameEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   OnPointersAdd:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   OnPointersUpdate:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   OnPointersPress:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   OnPointersRelease:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   OnPointersRemove:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   OnPointersCancel:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   basicEditor: 1
   displayDevice: {fileID: 0}
@@ -12640,6 +12640,7 @@ MonoBehaviour:
   frontPanel: {fileID: 744158707}
   refinePanel: {fileID: 482620883}
   congratsPanel: {fileID: 1987047126}
+  helperNumStages: 5
 --- !u!114 &905924068
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12748,7 +12749,7 @@ MonoBehaviour:
   OnStateChange:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   basicEditor: 0
   generalProps: 0
@@ -12798,7 +12799,7 @@ MonoBehaviour:
   OnStateChange:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   basicEditor: 0
   generalProps: 0
@@ -29110,7 +29111,7 @@ MonoBehaviour:
   OnStateChange:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   basicEditor: 1
   generalProps: 0
@@ -29128,17 +29129,17 @@ MonoBehaviour:
   OnTransformStart:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   OnTransform:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   OnTransformComplete:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6646.1845,
+    m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=1.0.6656.3675,
       Culture=neutral, PublicKeyToken=null
   type: 2
   screenTransformThreshold: 0.1

--- a/Assets/Scripts/Andrew's Scripts/EventPlayer.cs
+++ b/Assets/Scripts/Andrew's Scripts/EventPlayer.cs
@@ -450,7 +450,7 @@ public class EventPlayer : MonoBehaviour {
 
                 if (truePath != null)
                 {
-                    truePath.enabled = swipeGameMode.GetComponent<SwipeGameMode>().isSoftTutorial() || playingTutorial;
+                    if (swipeGameMode.GetComponent<SwipeGameMode>().isSoftTutorial() || playingTutorial) truePath.enabled = true;
                     truePath.SetPosition(0, events[currEventNumber].startPos);
                     truePath.SetPosition(1, events[currEventNumber].endPos);
                 }

--- a/Assets/Scripts/Andrew's Scripts/SwipeGameMode.cs
+++ b/Assets/Scripts/Andrew's Scripts/SwipeGameMode.cs
@@ -153,11 +153,6 @@ public class SwipeGameMode : MonoBehaviour {
                     softTutorialText.SetActive(false);
                 }
 
-                if (eventPlayer != null)
-                {
-                    eventPlayer.truePath.enabled = false;
-                }
-
                 StopGame();
             }
 
@@ -188,11 +183,6 @@ public class SwipeGameMode : MonoBehaviour {
                         tutorial.GetComponent<Tutorial>().playTutorial = true;
                     }
 
-                    if (eventPlayer != null)
-                    {
-                        eventPlayer.truePath.enabled = false;
-                    }
-
                     if(instructionChoice != null)
                     {
                         instructionChoice.SetActive(false);
@@ -215,39 +205,42 @@ public class SwipeGameMode : MonoBehaviour {
 
     public void summaryDone()
     {
-         //reset main camera
-         mainCamera.transform.localPosition = new Vector3(300.2444f, 342.7338f, -3306.132f);
-         mainCamera.transform.localEulerAngles = new Vector3(23.002f, -5.327f, 0);
+        //reset main camera
+        mainCamera.transform.localPosition = new Vector3(300.2444f, 342.7338f, -3306.132f);
+        mainCamera.transform.localEulerAngles = new Vector3(23.002f, -5.327f, 0);
          
-         if (tutorial != null)
-         {
-             tutorial.GetComponent<Tutorial>().playTutorial = true;
-         }
+        if (tutorial != null)
+        {
+            tutorial.GetComponent<Tutorial>().playTutorial = true;
+        }
 
-         if (eventPlayer != null)
-         {
-             eventPlayer.truePath.enabled = false;
-         }
+        if (startButton != null)
+        {
+            startButton.SetActive(true);
+        }
 
-         if (startButton != null)
-         {
-             startButton.SetActive(true);
-         }
-
-         if (summaryPanel != null)
-         {
-             summaryPanel.SetActive(false);
+        if (summaryPanel != null)
+        {
+            summaryPanel.SetActive(false);
  
-             foreach (Transform child in summaryPanel.transform)
-             {
-                 if (child.gameObject.name.StartsWith("Event:"))
-                 {
-                     Destroy(child.gameObject);
-                 }
-             }
+            foreach (Transform child in summaryPanel.transform)
+            {
+                if (child.gameObject.name.StartsWith("Event:"))
+                {
+                    Destroy(child.gameObject);
+                }
+            }
  
-             summaryPanel.GetComponent<EventPanelManager>().panels.Clear();
-         }
+            summaryPanel.GetComponent<EventPanelManager>().panels.Clear();
+        }
+
+        if (eventPlayer != null)
+        {
+            eventPlayer.truePath.enabled = false;
+            Color newColor = eventPlayer.truePath.material.color;
+            newColor.a = 1f;
+            eventPlayer.truePath.material.color = newColor;
+        }
     }
 
     public void InstructionChoice(bool yes)
@@ -260,7 +253,6 @@ public class SwipeGameMode : MonoBehaviour {
 
         if (eventPlayer != null)
         {
-            eventPlayer.truePath.enabled = false;
             eventPlayer.GetComponent<EventPlayer>().keepPlaying = true;
             eventPlayer.GetComponent<EventPlayer>().StopCurrentEvent();
             eventPlayer.GetComponent<EventPlayer>().StopTutorialEvent();

--- a/Assets/Scripts/SwipeRecognizer.cs
+++ b/Assets/Scripts/SwipeRecognizer.cs
@@ -63,6 +63,8 @@ public class SwipeRecognizer : MonoBehaviour {
     public GameObject refinePanel;
     public GameObject congratsPanel;
 
+    public float helperNumStages = 5f;
+
     private Vector3 totalVector = Vector3.zero;
     private Vector3 totalScore = Vector3.zero;
 
@@ -827,6 +829,18 @@ public class SwipeRecognizer : MonoBehaviour {
             // for missing event on SwipeGameMode class
             swipeGameMode.SetTimePenaltyByPercent(
                 2 * (goalAccuracy - initialSwipeAccuracy));
+
+            Color newColor = currentEvents.truePath.material.color;
+            if (newColor.a > 0f && currentEvents.truePath.enabled)
+            {
+                newColor.a -= 1f / helperNumStages; // alpha decreases linearly as function of success
+                if (newColor.a < 0.1f) // If success >= 6
+                {
+                    currentEvents.truePath.enabled = false;
+                    newColor.a = 1f;
+                }
+            }
+            currentEvents.truePath.material.color = newColor;
         }
 
         yield return new WaitForSeconds(waittime);

--- a/Assets/Scripts/Tutorial.cs
+++ b/Assets/Scripts/Tutorial.cs
@@ -54,7 +54,7 @@ public class Tutorial : MonoBehaviour {
                         {
                             e.StopCurrentEvent();
                             e.StopTutorialEvent();
-                            e.truePath.enabled = false;
+                            e.truePath.enabled = true;
                             //e.scaleArray(3f);
                         }
                     }


### PR DESCRIPTION
- Line used to guide users in tutorial is now used throughout the game as well.
- The line becomes more transparent as the user progresses through the game so as to reinforce the idea learn through the guidance of the helper line that he/she should recognize on his/her own the line the neutrino passed through.
- SwipeRecognizer now includes a variable now to set the number of stages in which the helper line is visible. Stages are advanced by successfully detecting neutrinos in-game and on each success, the helper line becomes linearly more transparent (1/numStages one each stage advanced) until it is invisible. For instance, setting the stage variable to 3 means that after the first user success in detecting a neutrino, the helper line will become 1/3 more transparent; after the second success, the helper line will become 2/3 transparent; after 3 and subsequent successes, the helper line is removed and the player now does not have those "training wheels" anymore.